### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,22 @@
 You can found the Windows driver for wb32-dfu-updater_cli in the `driver` directory.
 
 To install the Windows driver for wb32-dfu-updater_cli, you should unzip the package and run `winusb_install.bat`.
+
+## Linux bash error
+
+If you encounter either of the following errors
+
+``` bash: ./bootstrap.sh: cannot execute: required file not found ```
+
+or
+
+``` ./bootstrap.sh: line 2: $'\r': command not found ```
+
+then you will need to convert bootstrap.sh from DOS to Unix encoding before attempting to run the script.
+
+
+The easiest way to do this is by using the CLI tool dos2unix.
+
+``` sudo apt install dos2unix ```
+
+``` dos2unix bootstrap.sh ```


### PR DESCRIPTION
Updated the readme to include an extra step necessary on some linux systems.

I encountered this error when attempting to run the script on Ubuntu 22.10 with bash 5.2.2(1).
It appears that the DOS encoding (presumably necessary for mingw64?) causes issues with some linux systems.
This PR highlights the error that one such user might encounter, and the steps to work around it.