### PR TITLE
Require cmake version 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 
 set(CMAKE_C_STANDARD 99)
 


### PR DESCRIPTION
Versions <3.10 are deprecated in cmake 4 and will lose support.
See also https://github.com/NixOS/nixpkgs/issues/445447
